### PR TITLE
Bug Fix: Bio Length

### DIFF
--- a/database/migrations/20190820212313-create-users.js
+++ b/database/migrations/20190820212313-create-users.js
@@ -31,7 +31,7 @@ module.exports = {
         allowNull: true
       },
       biography: {
-        type: Sequelize.STRING,
+        type: Sequelize.TEXT,
         allowNull: true
       },
       profile_picture: {


### PR DESCRIPTION
Changed bio type to TEXT to allow for longer bios. Sequelize has a character limit for strings. More info: https://codewithhugo.com/sequelize-data-types-a-practical-guide/

Bio length limit will be set on the FE. 